### PR TITLE
Implement forum commands

### DIFF
--- a/src/units/forum.js
+++ b/src/units/forum.js
@@ -1,0 +1,46 @@
+const { Unit } = require('../lib/units.js');
+const { GodotEmbedBuilder } = require('../lib/helpers.js');
+
+const urlForum = 'https://forum.godotengine.org/';
+const urlTricks = 'https://forum.godotengine.org/c/resources/tips-tricks/22';
+
+const shareEmbed = new GodotEmbedBuilder()
+	.setTitle('Spread the Knowledge!')
+	.setDescription(
+		'Content on discord is not indexed by search engines. It would be awesome if you '
+		+ `can post useful tips and tricks on [the forum](${urlForum}) :sparkles:\n\n`
+		+ `There even is an extra [category](${urlTricks}) for sharing your favorite tricks!`,
+	)
+;
+
+const complexEmbed = new GodotEmbedBuilder()
+	.setTitle('Ask complex questions on the Forum')
+	.setDescription(
+		'For long questions, you may get better and more detailed help by asking on '
+		+ `[the forum](${urlForum}) :sparkles:\n\nDiscord is great as a chat platform, but since `
+		+ 'it is real-time it also means questions get easily overlooked if they '
+		+ 'can\'t be answered quickly.',
+	)
+;
+
+const unit = new Unit();
+
+unit.createCommand()
+	.setName('share')
+	.setRateLimit(0)
+	.setDescription('Suggests to post tips and tricks on the forum')
+	.setCallback(async interaction => {
+		await interaction.reply({ embeds: [shareEmbed] });
+	})
+;
+
+unit.createCommand()
+	.setName('complex')
+	.setRateLimit(0)
+	.setDescription('Suggests to ask complex questions on the forum')
+	.setCallback(async interaction => {
+		await interaction.reply({ embeds: [complexEmbed] });
+	})
+;
+
+module.exports = unit;


### PR DESCRIPTION
Adds two commands:
- `/share` encourages users to share tips and tricks on the forum. Intended usecase: Someone posted an awesome code snippet or trick on discord, and the community would benefit from having that indexed by search engines. So other people can reply with this command.
- `/complex` tells people to ask on the forum to get more detailed support. Intended usecase: Someone asks a long/complex question that would be better suited for the forum, or someone asks "why is nobody answering me here?". Other users can then reply with this command to let them know about the forum.