### PR TITLE
Class name check + fix deprecated ephemeral

### DIFF
--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -9,6 +9,7 @@ const {
 	ChannelType,
 	REST,
 	Routes,
+	MessageFlags,
 } = require('discord.js');
 const { Unit, RateLimitError } = require('./units.js');
 const path = require('node:path');
@@ -143,7 +144,7 @@ class ModularClient extends Client {
 		const cmd = this.#slashCommands.get(interaction.commandName);
 		if (!cmd) {
 			console.error(ModularClient.ERR_INVALID_CMD, interaction.commandName);
-			await interaction.reply({ content: ModularClient.MSG_SERVER_ERROR, ephemeral: true });
+			await interaction.reply({ content: ModularClient.MSG_SERVER_ERROR, flags: MessageFlags.Ephemeral });
 			return;
 		}
 
@@ -161,10 +162,10 @@ class ModularClient extends Client {
 			}
 			// Send the message using either a follow up or a reply
 			if (interaction.replied || interaction.deferred) {
-				await interaction.followUp({ content: msg, ephemeral: true });
+				await interaction.followUp({ content: msg, flags: MessageFlags.Ephemeral });
 			}
 			else {
-				await interaction.reply({ content: msg, ephemeral: true });
+				await interaction.reply({ content: msg, flags: MessageFlags.Ephemeral });
 			}
 		}
 	}
@@ -177,7 +178,7 @@ class ModularClient extends Client {
 		const cmd = this.#contextCommands.get(interaction.commandName);
 		if (!cmd) {
 			console.error(ModularClient.ERR_INVALID_CMD, interaction.commandName);
-			await interaction.reply({ content: ModularClient.MSG_SERVER_ERROR, ephemeral: true });
+			await interaction.reply({ content: ModularClient.MSG_SERVER_ERROR, flags: MessageFlags.Ephemeral });
 			return;
 		}
 
@@ -195,10 +196,10 @@ class ModularClient extends Client {
 			}
 			// Send the message using either a follow up or a reply
 			if (interaction.replied || interaction.deferred) {
-				await interaction.followUp({ content: msg, ephemeral: true });
+				await interaction.followUp({ content: msg, flags: MessageFlags.Ephemeral });
 			}
 			else {
-				await interaction.reply({ content: msg, ephemeral: true });
+				await interaction.reply({ content: msg, flags: MessageFlags.Ephemeral });
 			}
 		}
 	}

--- a/src/units/ping.js
+++ b/src/units/ping.js
@@ -1,3 +1,4 @@
+const { MessageFlags } = require('discord.js');
 const { Unit } = require('../lib/units.js');
 
 const unit = new Unit();
@@ -6,7 +7,7 @@ unit.createCommand()
 	.setName('ping')
 	.setDescription('Ping Pong')
 	.setCallback(async interaction => {
-		await interaction.reply({ content: 'pong', ephemeral: true });
+		await interaction.reply({ content: 'pong', flags: MessageFlags.Ephemeral });
 	})
 ;
 


### PR DESCRIPTION
Primarily this resolves #9 by sending an https get request to the generated godot docs link. If the godot docs reply with a status 200, the embed with the link is sent just like before. Otherwise, an ephemeral message is sent informing the user that the class was not found in the docs with the recommendation to search the docs themselves including the docs link to the correct version, or to use the offline docs in godot.

While this does not fully include the fuzzy matching mentioned in the issue, I did add a regex that removes all spaces so searching "Node 2D" still comes up with the result just like "Node2D".
<img width="931" height="722" alt="image" src="https://github.com/user-attachments/assets/c1a30f3d-7521-43ea-a445-f18be7159a8c" />

For the requests I used the node native https module, so no additional npm packages required. Not sure since what node version this is available, but I tried it with my installed node v18, which is also required by some other dependency so it should be fine. And the docker file is using node v20 anyways. In the issue caching was mentioned as idea, but since the also mentioned rate limits are implemented by now this should be obsolete. 



Another small thing I noticed is this deprecation warning by discord.js coming from using `ephemeral: true`.
<img width="1640" height="55" alt="image" src="https://github.com/user-attachments/assets/104b6b0c-e487-48d9-b5ce-5a0a1fd57b46" />
Instead you're now supposed to use flags. I updated that for wherever ephemeral messages are used. Requires to import `MessageFlags` from discord.js.