### PR TITLE
updated report messages

### DIFF
--- a/src/units/context-report.js
+++ b/src/units/context-report.js
@@ -17,14 +17,36 @@ unit.createContextMenuCommand()
 		const reportedMessage = interaction.targetMessage;
 		const embed = new GodotEmbedBuilder()
 			.setAuthor({ name: interaction.user.username, iconURL: interaction.user.avatarURL() ?? interaction.user.defaultAvatarURL })
-			.setDescription(reportedMessage.content || 'No content');
+			.setDescription(reportedMessage.content || '-# no content');
+		const embeds = [embed];
 		const msg = `<@&${modRole}> New report created by <@${interaction.user.id}>\n`
 		+ `:link:Link: https://discord.com/channels/${interaction.guildId}/${interaction.channelId}/${interaction.targetId}`;
 		const files = [];
+		const largeFiles = [];
+		let uploadLimit = 1024 * 1024 * 8; // 8mb
+		switch (interaction.guild.premiumTier) {
+			case 2: uploadLimit = 1024 * 1024 * 50; break;
+			case 3: uploadLimit = 1024 * 1024 * 100; break;
+		}
+		uploadLimit = uploadLimit * 0.95; // small buffer
 		reportedMessage.attachments.forEach(attachment => {
-			files.push(attachment.url);
+			if (attachment.size > uploadLimit) {
+				largeFiles.push(attachment.url);
+			} else {
+				files.push(attachment.url);
+			}
 		});
-		channel.send({ content: msg, embeds: [embed], files: files });
+		if (largeFiles.length > 0) {
+			let embedDescription = 'These files were too large to attach to this report:';
+			largeFiles.forEach(file => {
+				embedDescription += '\n' + file;
+			});
+			const largeFilesEmbed = new GodotEmbedBuilder()
+				.setTitle('Large Files')
+				.setDescription(embedDescription);
+			embeds.push(largeFilesEmbed);
+		}
+		channel.send({ content: msg, embeds: embeds, files: files });
 		await interaction.reply({ flags: MessageFlags.Ephemeral, content: 'Message has been reported. A staff member will check soon.' });
 	});
 


### PR DESCRIPTION
Resolves #22 .

I changed the message that is sent to the mods when reporting a message like described in the issue and sticked to the mockup.
For the authors pfp this has a fallback to the pink default pfp in case the user has no pfp. Used the pink one cause that's the one discord gave me so I could just extract the used asset link from the browser. Seems to not be possible to check which color a user got. It's also worth noting that discord.js probably always provides the users global pfp and not the server specific pfp if they have one.

I also made it so files that were included in the original message get sent to the mods too, but it has to be mentioned that for this I had to use an experimental discord.js feature which gives this node warning:
<img width="1455" height="58" alt="image" src="https://github.com/user-attachments/assets/ba610034-7b46-4717-a16b-3ff2c0a6d949" />
From my testing it seems to work without any issues. The embeds description also has a fallback to "No content" in case the user only sends a file because it errors out when passing an empty string.

Here's how it now looks:
<img width="937" height="1162" alt="image" src="https://github.com/user-attachments/assets/a72f60fe-5b81-4788-b61e-e15dc0202829" />
