### PR TITLE
fix: corrected gdscript command description

### DIFF
--- a/src/units/gdscript.js
+++ b/src/units/gdscript.js
@@ -16,7 +16,7 @@ const unit = new Unit();
 unit.createCommand()
     .setName('gdscript')
     .setRateLimit(10)
-    .setDescription('Explains to not ask in multiple channels')
+    .setDescription('Provides resources for learning GDScript')
     .setCallback(async interaction => {
         await interaction.reply({ embeds: [embedRepost] })
     })


### PR DESCRIPTION
Fixes #32

The `gdscript` command description previously said 
"Explains to not ask in multiple channels," which was incorrect.  

This PR updates the description to accurately reflect the command’s 
purpose: providing resources for learning GDScript.
