### PR TITLE
Class Fetching

### DIFF
--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -10,6 +10,7 @@ const {
 	REST,
 	Routes,
 	AutocompleteInteraction,
+	MessageFlags,
 } = require('discord.js');
 const classFetch = require('../utils/fetch-godot-classes');
 const { Unit, RateLimitError } = require('./units.js');
@@ -151,7 +152,7 @@ class ModularClient extends Client {
 
 		if (!cmd) {
 			console.error(ModularClient.ERR_INVALID_CMD, interaction.commandName);
-			await interaction.reply({ content: ModularClient.MSG_SERVER_ERROR, ephemeral: true });
+			await interaction.reply({ content: ModularClient.MSG_SERVER_ERROR, flags: MessageFlags.Ephemeral });
 			return;
 		}
 
@@ -169,10 +170,10 @@ class ModularClient extends Client {
 			}
 			// Send the message using either a follow up or a reply
 			if (interaction.replied || interaction.deferred) {
-				await interaction.followUp({ content: msg, ephemeral: true });
+				await interaction.followUp({ content: msg, flags: MessageFlags.Ephemeral });
 			}
 			else {
-				await interaction.reply({ content: msg, ephemeral: true });
+				await interaction.reply({ content: msg, flags: MessageFlags.Ephemeral });
 			}
 		}
 	}
@@ -185,7 +186,7 @@ class ModularClient extends Client {
 		const cmd = this.#contextCommands.get(interaction.commandName);
 		if (!cmd) {
 			console.error(ModularClient.ERR_INVALID_CMD, interaction.commandName);
-			await interaction.reply({ content: ModularClient.MSG_SERVER_ERROR, ephemeral: true });
+			await interaction.reply({ content: ModularClient.MSG_SERVER_ERROR, flags: MessageFlags.Ephemeral });
 			return;
 		}
 
@@ -203,10 +204,10 @@ class ModularClient extends Client {
 			}
 			// Send the message using either a follow up or a reply
 			if (interaction.replied || interaction.deferred) {
-				await interaction.followUp({ content: msg, ephemeral: true });
+				await interaction.followUp({ content: msg, flags: MessageFlags.Ephemeral });
 			}
 			else {
-				await interaction.reply({ content: msg, ephemeral: true });
+				await interaction.reply({ content: msg, flags: MessageFlags.Ephemeral });
 			}
 		}
 	}

--- a/src/units/getting-help.js
+++ b/src/units/getting-help.js
@@ -24,7 +24,8 @@ const embedQuestions = new GodotEmbedBuilder()
 				+ '- What are you trying to do? (show your node setup / code)\n'
 				+ '- What is the expected result?\n'
 				+ '- What is happening instead? (include any error messages)\n'
-				+ '- What have you tried so far?',
+				+ '- What have you tried so far?\n'
+				+ '- What type of game is this, 2D or 3D?',
 		},
 		{
 			name: 'Respond to Helpers',

--- a/src/units/ping.js
+++ b/src/units/ping.js
@@ -1,3 +1,4 @@
+const { MessageFlags } = require('discord.js');
 const { Unit } = require('../lib/units.js');
 
 const unit = new Unit();
@@ -6,7 +7,7 @@ unit.createCommand()
 	.setName('ping')
 	.setDescription('Ping Pong')
 	.setCallback(async interaction => {
-		await interaction.reply({ content: 'pong', ephemeral: true });
+		await interaction.reply({ content: 'pong', flags: MessageFlags.Ephemeral });
 	})
 ;
 


### PR DESCRIPTION
Resolves #9, replaces #25 and expands #30.

As we discussed in the above mentioned issues and PRs, I now did the autocompletion for the /class command based upon the classes that are fetched from the godot docs site and parsed into the .csc file.

My approach now makes use of the discord.js `.setAutocomplete(true)` property of command options as well as the `AutocompleteInteraction` event. This means every time the user enters something in the search field for classes, this is sent to the server where the input is compared to the available classes and then a list of matches is returned for the user to pick from. Like a normal search that most people should be used to.
This means more server load and network traffic, but greatly improved responsiveness and ease of use.

The CSV files are now cached inside the docs.js unit. On each AutocompleteInteraction event, the modification date of the corresponding CSV file is checked and based on that either the cached version is being used, or the cache is being refreshed with the new contents. This prevents full file reads for every interactio, while allowing changes to the CSV file like from using the refresh command to be immidiately effective in the command.
Due to the architecture used so far, I didn't find a different way to tie the "fetch classes" command to refreshing the cache since these two files are basically isolated from eachother with no bridge for interaction, but should be fine this way.

I also made it so these callbacks for the autocompletion are added the same way as the interaction callbacks, so it's modular and could be used for different commands as well. Didn't want to hardcode docs logic anywhere else besides the docs unit file.

https://github.com/user-attachments/assets/fb5af656-d1a8-41a0-b231-b2cfb32c28d7

