### PR TITLE
Fix broken link to discord.js in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ but can be used for other servers too.
 
 ### Obtaining a Token
 
-Please follow the [discord.js Guide](https://discordjs.guide/preparations/setting-up-a-bot-application.html#creating-your-bot)
+Please follow the [discord.js Guide](https://discordjs.guide/legacy/preparations/app-setup)
 for creating an application and getting a token.
 
 ### Configuring the Bot


### PR DESCRIPTION
The current link for setting up a Discord bot, https://discordjs.guide/preparations/setting-up-a-bot-application.html#creating-your-bot, leads to a 404 page. This PR updates it to (what appears to be) the current URL, https://discordjs.guide/legacy/preparations/app-setup .

I did note that the URL has "legacy" in it, suggesting that perhaps there should be a "non-legacy" (aka current) version, but following their website links, I was just taken back to this page.