### PR TITLE
Add "Waiting for Godot" daily updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Create a JavaScript file at `./instance/config.js` with the following content, o
 const config = {
   clientId: "CLIENT_ID",
   token: "TOKEN",
+  githubToken: 'GITHUB_TOKEN',
   admins: [],
   docVersions: {
     3: { displayName: "Godot 3 (LTS)", urlFragment: "3.6" },
@@ -39,6 +40,8 @@ commands registered for the discord application. At the very least this list sho
 contain your own user ID.
 The `"guildConfigs"` field should list all guild IDs that the commands should be registered
 in, followed with the channel used for moderation alerts, and moderator role that should be pinged in that server.
+
+The `"githubToken"` field should be a GitHub API token (such as a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)), used for querying the Godot repositories with the "Waiting for Godot" functionality.
 
 ## Running the Bot
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ const config = {
     4: { displayName: "Godot 4 (stable)", urlFragment: "stable" },
   },
   guildConfigs: {
-    "GUILD_ID": { modChannel: "CHANNEL_ID", modRole: "ROLE_ID" },
+    "GUILD_ID": { modChannel: "CHANNEL_ID", modRole: "ROLE_ID", waitingForGodotChannel: 'CHANNEL_ID' },
   },
 };
 
@@ -42,6 +42,7 @@ The `"guildConfigs"` field should list all guild IDs that the commands should be
 in, followed with the channel used for moderation alerts, and moderator role that should be pinged in that server.
 
 The `"githubToken"` field should be a GitHub API token (such as a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)), used for querying the Godot repositories with the "Waiting for Godot" functionality.
+The `"waitingForGodotChannel"` field should be a channel ID within the guild where the bot should post the daily "Waiting for Godot" messages.
 
 ## Running the Bot
 

--- a/instance/exampleConfig.js
+++ b/instance/exampleConfig.js
@@ -5,7 +5,7 @@
 const config = {
 	clientId: 'CLIENT_ID',
 	token: 'TOKEN',
-	github_token: 'GITHUB_TOKEN',
+	githubToken: 'GITHUB_TOKEN',
 	admins: [],
 	docVersions: {
 		'3': { displayName: 'Godot 3 (LTS)', urlFragment: '3.6' },

--- a/instance/exampleConfig.js
+++ b/instance/exampleConfig.js
@@ -12,7 +12,7 @@ const config = {
 		'4': { displayName: 'Godot 4 (stable)', urlFragment: 'stable' },
 	},
 	guildConfigs: {
-		'GUILD_ID': { modChannel: 'CHANNEL_ID', modRole: 'ROLE_ID' },
+		'GUILD_ID': { modChannel: 'CHANNEL_ID', modRole: 'ROLE_ID', waitingForGodotChannel: 'CHANNEL_ID' },
 	},
 };
 

--- a/instance/exampleConfig.js
+++ b/instance/exampleConfig.js
@@ -5,6 +5,7 @@
 const config = {
 	clientId: 'CLIENT_ID',
 	token: 'TOKEN',
+	github_token: 'GITHUB_TOKEN',
 	admins: [],
 	docVersions: {
 		'3': { displayName: 'Godot 3 (LTS)', urlFragment: '3.6' },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "axios": "^1.11.0",
         "cheerio": "^1.1.2",
+        "cron": "^4.3.4",
         "discord.js": "^14.22.1"
       },
       "devDependencies": {
@@ -386,6 +387,12 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
+    "node_modules/@types/luxon": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.1.tgz",
+      "integrity": "sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.3.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
@@ -735,6 +742,19 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/cron": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-4.3.4.tgz",
+      "integrity": "sha512-OiO0l73MGhQOZQCjYZ0v7r8yFWpBOWteemwR1RIxiHtfVsIOwiTJZDvg7GmKzggkwC0RO8tI3P1QYBUCIZNYRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.7.0",
+        "luxon": "~3.7.0"
+      },
+      "engines": {
+        "node": ">=18.x"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1655,6 +1675,15 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
       "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/magic-bytes.js": {
       "version": "1.12.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "axios": "^1.11.0",
     "cheerio": "^1.1.2",
+    "cron": "^4.3.4",
     "discord.js": "^14.22.1"
   },
   "devDependencies": {

--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -30,6 +30,7 @@ const { createReport } = require('../utils/waiting-for-godot');
  * @typedef ModularClientConfig
  * Configuration data for a ModularClient
  * @property {string} token Discord API token
+ * @property {string} githubToken GitHub access token
  * @property {string[]} admins List of user IDs that are allowed to administrate the bot
  * @property {{[key:string]: {displayName: string, urlFragment: string}}} docVersions
  * @property {string} clientId ID of the Discord application

--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -76,9 +76,15 @@ class ModularClient extends Client {
 		this.on(Events.InteractionCreate, this.#onInteractionCreate);
 		this.on(Events.MessageCreate, this.#onMessageCreate);
 		this.once(Events.ClientReady, c => {
-			let waitingForGodotJob = new cron.CronJob('0 0 * * *', async () => {
-				for (const guildId of Object.keys(config.guildConfigs)) {
-					console.log(`Running WfG at ${new Date().toLocaleString()}`);
+			for (const guildId of Object.keys(config.guildConfigs)) {
+				if (!('waitingForGodotChannel' in config.guildConfigs[guildId])) {
+					console.log(`No WfG channel set up for guild ${guildId}, so not setting up a job`);
+					continue;
+				}
+
+				let job = new cron.CronJob('0 0 * * *', async () => {
+					console.log(`Running WfG at ${new Date().toLocaleString()} for guild ${guildId}`);
+					
 					const guild = this.guilds.cache.get(guildId);
 					const channel = guild.channels.cache.get(config.guildConfigs[guildId].waitingForGodotChannel);
 					
@@ -86,9 +92,11 @@ class ModularClient extends Client {
 					for (const chunk of reportChunks) {
 						channel.send(chunk);
 					}
-				}
-			});
-			waitingForGodotJob.start();
+				});
+				job.start();
+				console.log(`WfG job set up for guild ${guildId}`);
+			}
+			
 			console.log(`Ready! Logged in as ${c.user.tag}`);
 		});
 

--- a/src/units/waiting-for-godot.js
+++ b/src/units/waiting-for-godot.js
@@ -1,0 +1,254 @@
+const { Unit } = require('../lib/units.js');
+const { MessageFlags } = require('discord.js');
+const unit = new Unit();
+
+const PROPOSALS_REPO = 'godotengine/godot-proposals';
+const ISSUES_REPO = 'godotengine/godot';
+
+const MAX_PAGES = 1;
+const MAX_ISSUES = 10;
+
+// TODO: Use previous day (check for new stuff etc)
+// TODO: Split post into multiple parts as necessary(?)
+// TODO: Use all 4.* instead of just 4.x milestone
+
+function createHeader() {
+    // TODO: Count the days
+    let header = `**Day XXX** :gdcute: \n`;
+    header += 'Waiting for **Godot 4.x dev/beta/rc/stable**\n\n';
+    return header;
+}
+
+function createFooter() {
+    let footer = 'For daily merged pull requests, visit [Github Pulse](<https://github.com/godotengine/godot/pulse/daily>).\n';
+    footer += 'Based on [source code by Qubrick](<https://github.com/Qubrick/WaitingReport>).\n';
+    footer += '\nSincerely, the Godot Bot.';
+    return footer;
+}
+
+async function getIssuesReport(milestone, repo, type, title, timefilter, state, stateReason = null, event = null) {
+    let countIssues = 0;
+    let output = "";
+
+    let labelList = { "core": "", "documentation":"", "editor":"", "gui":"", "input":"", "audio":"", 
+                "rendering":"", "shaders":"", "3d":"", "2d":"", "particles":"", "vfx":"", "animation":"",  
+                "physics":"", "codestyle":"", "gdscript":"", "dotnet":"", "visualscript":"",  "navigation":"", "multiplayer":"", "network":"", "xr":"", 
+                "plugin":"", "gdextension":"",
+                "buildsystem":"", "export": "", "import":"", "porting":"", "tests":"", "thirdparty":"" }
+
+    const specialCategoryNames = {
+        "gui": "GUI",
+        "3d": "3D",
+        "2d": "2D",
+        "vfx": "VFX",
+        "gdscript": "GDScript",
+        "dotnet": ".NET",
+        "visualscript": "VisualScript",
+        "xr": "XR",
+        "gdextension": "GDExtension",
+        "thirdparty": "Third-Party"
+    };
+
+    let issuesCollected = new Set();
+
+    for (let i = 0; i < MAX_PAGES + 1; i++) {
+        // TODO: add time filter
+
+        const url = new URL(`https://api.github.com/search/issues`);
+        url.search = new URLSearchParams({
+            q: `repo:${repo} is:${type} milestone:${milestone} state:${state}`,
+            per_page: MAX_ISSUES.toString(),
+            page: i.toString(),
+            sort: 'updated'
+        }).toString();
+
+        const response = await fetch(url, {
+            method: 'GET',
+            headers: {
+                'Authorization': `Bearer ${TOKEN}`
+            }
+        });
+        const data = await response.json();
+        if (!('total_count' in data) || data.total_count <= 0) {
+            break; // If it stops here, then there shouldn't be more pages???
+        }
+
+        for (const s of data.items) {
+            const reason = s.state_reason;
+            let foundEvent = true;
+
+            // TODO: Check if event existed after last time
+            if ((!stateReason || s.state_reason == stateReason) && foundEvent) {
+                let prefix = '';
+
+                if ('pull_request' in s && !reason) {
+                    if (s.pull_request.merged_at) {
+                        prefix = ':purple_circle: [M][PR]';
+                    } else {
+                        prefix = ':red_circle: [C][PR]';
+                    }
+                } else {
+                    if (reason == 'completed') {
+                        prefix = ':purple_circle: [C]';
+                    } else if (reason == 'not_planned') {
+                        prefix = ':red_circle: [N]';
+                    } else if (reason == 'reopened') {
+                        prefix = ':green_circle: [R]';
+                    } else if (reason == 'duplicate') {
+                        prefix = ':black_circle: [D]';
+                    }
+                }
+
+                // Prevent double-display of issues
+                if (issuesCollected.has(s.number)) {
+                    continue;
+                }
+                issuesCollected.add(s.number);
+
+                let c = `${prefix} [#${s.number}](<${s.html_url}>): ${s.title}\n`;
+                let approved = false;
+                let t = '';
+
+                for (const l of s.labels) {
+                    if (!approved) {
+                        if (l.name.includes('topic:') || l.name.includes('documentation')) {
+                            t = l.name.replace('topic:', '');
+                            approved = true;
+                        } else {
+                            t = l.name;
+                        }
+                    }
+                }
+
+                if (labelList.hasOwnProperty(t)) {
+                    labelList[t] += c;
+                } else {
+                    labelList[t] = c;
+                }
+
+                countIssues += 1;
+            }
+        }
+    }
+
+    if (countIssues <= 0) {
+        return null;
+    }
+
+    for (const l of Object.keys(labelList)) {
+        if (labelList[l].trim().length > 0) {
+            output += `__**`;
+            output += `${l in specialCategoryNames ? specialCategoryNames[l] : (l.charAt(0).toUpperCase() + l.slice(1))}`;
+            output += `**__\n${labelList[l].trim()}\n\n`;
+        }
+    }
+
+    return `**${title}${countIssues > 1 ? 's' : ''} (${countIssues}):**\n${output}\n\n`;
+}
+async function getAllIssuesReport(milestone, repo, title, timefilter, state, stateReason = null, event = null) {
+    let tmp = "";
+
+    let c = await getIssuesReport(milestone, repo, 'pull-request', `${state} Pull Request`, timefilter, state, stateReason, event);
+    if (c) {
+        tmp += `${c}~~----------------------------------------------------~~\n\n`;
+    }
+
+    c = await getIssuesReport(milestone, repo, 'issue', title, timefilter, state, stateReason, event);
+    if (c) {
+        tmp += c;
+    }
+
+    return tmp;
+}
+
+async function getMilestonesReport(repo, header, title, filter = '^4.x') {
+    const response = await fetch(`https://api.github.com/repos/${repo}/milestones`, {
+        method: 'GET',
+        headers: {
+            'Authorization': `Bearer ${TOKEN}`
+        }
+    });
+    const data = await response.json();
+    let tmp = "";
+    for (const item of data) {
+        if (item.title.search(filter) < 0) {
+            continue;
+        }
+        // TODO: add check for new
+
+        let num_open_issues = item.open_issues;
+        let num_closed_issues = item.closed_issues;
+        let complete_percent = 0.0;
+
+        console.log(`${header} ${item.title} - ${num_open_issues} open / ${num_closed_issues} closed`);
+
+        if (num_open_issues == 0 && num_closed_issues == 0) {
+            complete_percent = 0.0;
+        } else {
+            complete_percent = Math.floor(100.0 - ((num_open_issues * 100.0) / (num_open_issues + num_closed_issues)));
+        }
+
+        let contentExisted = false;
+        let t = "";
+
+        // Reopened Proposals
+        let c = await getAllIssuesReport(item.title, repo, `Reopened ${title}`, 'updated', 'open', 'reopened', 'reopened');
+        if (c.length > 0) {
+            contentExisted = true;
+            t += `${c}\n\n`
+        }
+
+        t = t.trim();
+        t += '\n\n\n';
+
+        // Closed Proposals
+        c = await getAllIssuesReport(item.title, repo, `Closed ${title}`, 'closed', 'closed');
+        if (c.length > 0) {
+            contentExisted = true;
+            t += `${c}\n\n`;
+        }
+
+        t = t.trim();
+
+        if (contentExisted) {
+            tmp += `\n**${header} ${item.title}:** ${complete_percent}% complete `;
+            tmp += `(${num_open_issues} open / ${num_closed_issues} closed)\n`;
+            tmp += t;
+        }
+    }
+
+    tmp = tmp.trim();
+    tmp += '\n\n';
+    return tmp;
+}
+
+async function createReport() {
+    let text = createHeader();
+
+    // Proposals
+    text += await getMilestonesReport(PROPOSALS_REPO, 'Proposals', 'Proposal');
+
+    // Issues
+    text += await getMilestonesReport(ISSUES_REPO, 'Milestones', 'Issue');
+
+    // Footer
+    text += createFooter();
+
+    console.log('THE BIG ENCHILADA:');
+    console.log(text);
+    console.log('END OF LARGE ENCHILADA');
+
+    console.log('PRECISE SIZE OF ENCHILADA:', text.length);
+    return text;
+}
+
+unit.createCommand()
+	.setName('waiting-for-godot')
+	.setRateLimit(10)
+	.setDescription('Explains how Godot is usually pronounced')
+	.setCallback(async interaction => {
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+		await interaction.editReply({ content: await createReport() });
+	});
+
+module.exports = unit;

--- a/src/units/waiting-for-godot.js
+++ b/src/units/waiting-for-godot.js
@@ -1,13 +1,16 @@
 const { Unit } = require('../lib/units.js');
 const { MessageFlags } = require('discord.js');
+const config = require('../../instance/config');
 const unit = new Unit();
 
 const PROPOSALS_REPO = 'godotengine/godot-proposals';
 const ISSUES_REPO = 'godotengine/godot';
 
-const MAX_PAGES = 2; // 2 in original Python
-const MAX_ISSUES = 100; // 100 in original Python
+const MAX_PAGES = 2;
+const MAX_ISSUES = 100;
 
+// The date of release of the last minor Godot version.
+// For example, Godot 4.5 was released 9 September 2025.
 const LAST_MINOR_RELEASE = new Date('2025-09-15');
 
 const specialCategoryNames = {
@@ -31,8 +34,6 @@ const typeAndStatus = {
     'reopened_issue': ':green_circle: [R]',
     'duplicate_issue': ':black_circle: [D]'
 };
-
-// TODO: Add a way to get GitHub token from config file
 
 function getDaysSinceLastRelease() {
     let diff = Date.now() - LAST_MINOR_RELEASE.valueOf();
@@ -77,7 +78,7 @@ async function getIssuesReport(milestone, repo, type, title, timefilter, state, 
         const response = await fetch(url, {
             method: 'GET',
             headers: {
-                'Authorization': `Bearer ${TOKEN}`
+                'Authorization': `Bearer ${config.github_token}`
             }
         });
         const data = await response.json();
@@ -94,7 +95,7 @@ async function getIssuesReport(milestone, repo, type, title, timefilter, state, 
                 let eventReq = await fetch(`https://api.github.com/repos/${repo}/issues/${s['number']}/events`, {
                     method: 'GET',
                     headers: {
-                        'Authorization': `Bearer ${TOKEN}`
+                        'Authorization': `Bearer ${config.github_token}`
                     }
                 });
                 const eventResponse = await eventReq.json();
@@ -185,7 +186,7 @@ async function getMilestonesReport(repo, header, title, filter = '^4\.') {
     const response = await fetch(`https://api.github.com/repos/${repo}/milestones`, {
         method: 'GET',
         headers: {
-            'Authorization': `Bearer ${TOKEN}`
+            'Authorization': `Bearer ${config.github_token}`
         }
     });
     const data = await response.json();

--- a/src/units/waiting-for-godot.js
+++ b/src/units/waiting-for-godot.js
@@ -78,7 +78,7 @@ async function getIssuesReport(milestone, repo, type, title, timefilter, state, 
         const response = await fetch(url, {
             method: 'GET',
             headers: {
-                'Authorization': `Bearer ${config.github_token}`
+                'Authorization': `Bearer ${config.githubToken}`
             }
         });
         const data = await response.json();
@@ -95,7 +95,7 @@ async function getIssuesReport(milestone, repo, type, title, timefilter, state, 
                 let eventReq = await fetch(`https://api.github.com/repos/${repo}/issues/${s['number']}/events`, {
                     method: 'GET',
                     headers: {
-                        'Authorization': `Bearer ${config.github_token}`
+                        'Authorization': `Bearer ${config.githubToken}`
                     }
                 });
                 const eventResponse = await eventReq.json();
@@ -186,7 +186,7 @@ async function getMilestonesReport(repo, header, title, filter = '^4\.') {
     const response = await fetch(`https://api.github.com/repos/${repo}/milestones`, {
         method: 'GET',
         headers: {
-            'Authorization': `Bearer ${config.github_token}`
+            'Authorization': `Bearer ${config.githubToken}`
         }
     });
     const data = await response.json();

--- a/src/utils/waiting-for-godot.js
+++ b/src/utils/waiting-for-godot.js
@@ -10,6 +10,13 @@ const MAX_ISSUES = 100;
 // For example, Godot 4.5 was released 9 September 2025.
 const LAST_MINOR_RELEASE = new Date('2025-09-15');
 
+// An optional emote to include after the day counter.
+// To use a server-specific emote, type the emote into
+// Discord, then prepend a backslash and send the message.
+// The emote string should appear like so:
+//   <:some_emote:123456789123456789>
+const EMOTE = ':robot:';
+
 const specialCategoryNames = {
     'gui': 'GUI',
     '3d': '3D',
@@ -45,8 +52,8 @@ function getOneDayAgo() {
 }
 
 function createHeader() {
-    let header = `**Day ${getDaysSinceLastRelease()}** :gdcute: \n`;
-    header += 'Waiting for **Godot 4.x dev/beta/rc/stable**\n\n';
+    let header = `**Day ${getDaysSinceLastRelease()}** ${EMOTE} \n`;
+    header += 'Waiting for Godot\n\n';
     return header;
 }
 

--- a/src/utils/waiting-for-godot.js
+++ b/src/utils/waiting-for-godot.js
@@ -1,7 +1,4 @@
-const { Unit } = require('../lib/units.js');
-const { MessageFlags } = require('discord.js');
-const config = require('../../instance/config');
-const unit = new Unit();
+const config = require('../../instance/config.js');
 
 const PROPOSALS_REPO = 'godotengine/godot-proposals';
 const ISSUES_REPO = 'godotengine/godot';
@@ -289,16 +286,4 @@ async function createReport() {
     return stringInChunks;
 }
 
-unit.createCommand()
-	.setName('waiting-for-godot')
-	.setRateLimit(10)
-	.setDescription('Explains how Godot is usually pronounced')
-	.setCallback(async interaction => {
-        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-        let reportItems = await createReport();
-        for (let i of reportItems) {
-            await interaction.followUp({ content: i });
-        }
-	});
-
-module.exports = unit;
+module.exports = { createReport };


### PR DESCRIPTION
This PR adds a port of [Qubrick's "Waiting for Godot"](https://github.com/Qubrick/WaitingReport) script to the Godot Bot.

Every day at midnight UTC time, the bot will post a message in the specified channel with a list of reopened and closed issues and PRs to the main Godot repo as well as the proposal repo.

Note that this introduces a dependency on the [`cron` package](https://www.npmjs.com/package/cron), so you will need to run `npm install` to add it.