### PR TITLE
Waiting for Godot - Set date of 4.6 release

### DIFF
--- a/src/utils/waiting-for-godot.js
+++ b/src/utils/waiting-for-godot.js
@@ -7,8 +7,9 @@ const MAX_PAGES = 2;
 const MAX_ISSUES = 100;
 
 // The date of release of the last minor Godot version.
-// For example, Godot 4.5 was released 9 September 2025.
-const LAST_MINOR_RELEASE = new Date('2025-09-15');
+// For example, Godot 4.5 was released 15 September 2025,
+// so during 4.6's development, this string was '2025-09-15'.
+const LAST_MINOR_RELEASE = new Date('2026-01-26');
 
 // An optional emote to include after the day counter.
 // To use a server-specific emote, type the emote into

--- a/src/utils/waiting-for-godot.js
+++ b/src/utils/waiting-for-godot.js
@@ -7,8 +7,9 @@ const MAX_PAGES = 2;
 const MAX_ISSUES = 100;
 
 // The date of release of the last minor Godot version.
-// For example, Godot 4.5 was released 9 September 2025.
-const LAST_MINOR_RELEASE = new Date('2025-09-15');
+// For example, Godot 4.5 was released 15 September 2025,
+// so during 4.6's development, this string was '2025-09-15'.
+const LAST_MINOR_RELEASE = new Date('2026-06-18');
 
 // An optional emote to include after the day counter.
 // To use a server-specific emote, type the emote into


### PR DESCRIPTION
This PR updates the date string in the Waiting for Godot functionality of the bot, so that it counts up from 26 January 2026 (the release date of Godot 4.6).

Note: In the future, perhaps it'd make sense to separate this date string out into a separate file that can be read from each time a new post is prepared, that way the bot wouldn't have to be stopped and restarted each time the date needs to be changed?